### PR TITLE
Fix build under windows and msvc

### DIFF
--- a/GL/gl.h
+++ b/GL/gl.h
@@ -1,10 +1,20 @@
 #ifndef __GL__H__
 #define __GL__H__
 
-#ifdef NANOGL_MANGLE_PREPEND
-#define GL_MANGLE( x ) p ## x
+#ifndef NANOGL_APIENTRY
+#if defined(_WIN32)
+#define NANOGL_APIENTRY __stdcall
 #else
-#define GL_MANGLE( x ) x
+#define NANOGL_APIENTRY
+#endif
+#endif
+
+#ifdef NANOGL_MANGLE_PREPEND
+#define GL_MANGLE( x ) NANOGL_APIENTRY p ## x
+#define GL_MANGLE_NAME( x ) p ## x
+#else
+#define GL_MANGLE( x ) NANOGL_APIENTRY x
+#define GL_MANGLE_NAME( x ) x
 #endif
 
 #ifdef __cplusplus
@@ -716,43 +726,32 @@ GLenum GL_MANGLE(glCheckFramebufferStatus)( GLenum target );
 void GL_MANGLE(glBindRenderbuffer)( GLenum target, GLuint renderbuffer );
 void GL_MANGLE(glDeleteRenderbuffers)( GLsizei n, const GLuint *renderbuffers );
 void GL_MANGLE(glGenRenderbuffers)( GLsizei n, GLuint *renderbuffers );
-
 void GL_MANGLE(glRenderbufferStorage)( GLenum target, GLenum internalformat, GLsizei width, GLsizei height );
-
 void GL_MANGLE(glFramebufferTexture2D)( GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level );
-
 void GL_MANGLE(glFramebufferRenderbuffer)( GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer );
 
 void GL_MANGLE(glNormalPointer)( GLenum type, GLsizei stride, const void *ptr );
 
 void GL_MANGLE(glMultiTexCoord3f)( GLenum, GLfloat, GLfloat, GLfloat );
 void GL_MANGLE(glMultiTexCoord3fARB)( GLenum, GLfloat, GLfloat, GLfloat );
-
 void GL_MANGLE(glMultiTexCoord2f)( GLenum, GLfloat, GLfloat );
 void GL_MANGLE(glMultiTexCoord2fARB)( GLenum, GLfloat, GLfloat );
 
-
 void GL_MANGLE(glDrawArrays)( GLenum mode, GLint first, GLsizei count );
 
-
 void GL_MANGLE(glBindBufferARB)( GLuint target, GLuint index );
-
 void GL_MANGLE(glGenBuffersARB)( GLuint count, GLuint *indexes );
-
 void GL_MANGLE(glDeleteBuffersARB)( GLuint count, GLuint *indexes );
-
 void GL_MANGLE(glBufferDataARB)( GLuint target, GLuint size, void *buffer, GLuint type );
-
 void GL_MANGLE(glBufferSubDataARB)( GLuint target, GLsizei offset, GLsizei size, void *buffer );
 
 GLboolean GL_MANGLE(glIsEnabled)( GLenum cap );
 
-typedef void ( *GL_DEBUG_PROC_ARB )( unsigned int source, unsigned int type, unsigned int id, unsigned int severity, int length, const char* message, void* userParam );
+typedef void ( NANOGL_APIENTRY *GL_DEBUG_PROC_ARB )( unsigned int source, unsigned int type, unsigned int id, unsigned int severity, int length, const char* message, void* userParam );
 void GL_MANGLE(glDebugMessageControlARB)( GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint* ids, GLboolean enabled );
 void GL_MANGLE(glDebugMessageInsertARB)( GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const char* buf );
 void GL_MANGLE(glDebugMessageCallbackARB)( GL_DEBUG_PROC_ARB callback, void* userParam );
 GLuint GL_MANGLE(glGetDebugMessageLogARB)( GLuint count, GLsizei bufsize, GLenum* sources, GLenum* types, GLuint* ids, GLuint* severities, GLsizei* lengths, char* messageLog );
-
 
 #ifdef __cplusplus
 }

--- a/GL/glesinterface.h
+++ b/GL/glesinterface.h
@@ -27,15 +27,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 #endif
 
+
+#ifdef _WIN32
+#include <windows.h> //APIENTRY
+#endif
+
 #ifdef SOFTFP_LINK
 #define S __attribute__( ( pcs( "aapcs" ) ) )
 #else
 #define S
 #endif
 
-#ifdef _WIN32
-#include <windows.h> //APIENTRY
-#endif
 #ifndef APIENTRY
 #ifdef _MSC_VER
 #define APIENTRY WINAPI
@@ -259,5 +261,7 @@ struct GlESInterface
 #pragma no_softfp_linkage
 #endif
 #endif
+
+#undef S
 
 #endif

--- a/eglwrap.cpp
+++ b/eglwrap.cpp
@@ -61,15 +61,15 @@ void *eglGetProcAddress( const char *procname )
 #if defined( __MULTITEXTURE_SUPPORT__ )
 	if ( !strcmp( procname, "glMultiTexCoord2fARB" ) )
 	{
-		return (void *)&GL_MANGLE(glMultiTexCoord2fARB);
+		return (void *)&GL_MANGLE_NAME(glMultiTexCoord2fARB);
 	}
 	else if ( !strcmp( procname, "glActiveTextureARB" ) )
 	{
-		return (void *)&GL_MANGLE(glActiveTexture);
+		return (void *)&GL_MANGLE_NAME(glActiveTexture);
 	}
 	else if ( !strcmp( procname, "glClientActiveTextureARB" ) )
 	{
-		return (void *)&GL_MANGLE(glClientActiveTexture);
+		return (void *)&GL_MANGLE_NAME(glClientActiveTexture);
 	}
 
 #endif

--- a/nanoWrap.cpp
+++ b/nanoWrap.cpp
@@ -1142,7 +1142,7 @@ void GL_MANGLE(glDisable)( GLenum cap )
 
 void GL_MANGLE(glVertex2f)( GLfloat x, GLfloat y )
 {
-	GL_MANGLE(glVertex3f)( x, y, 0.0f );
+	GL_MANGLE_NAME(glVertex3f)( x, y, 0.0f );
 }
 
 __FORCEINLINE unsigned int ClampTo255( float value )
@@ -1282,7 +1282,7 @@ void GL_MANGLE(glTexParameterf)( GLenum target, GLenum pname, GLfloat param )
 
 void GL_MANGLE(glTexParameterfv)( GLenum target, GLenum pname, const GLfloat *params )
 {
-	GL_MANGLE(glTexParameterf)( target, pname, params[0] );
+	GL_MANGLE_NAME(glTexParameterf)( target, pname, params[0] );
 }
 
 void GL_MANGLE(glTexImage2D)( GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid *pixels )
@@ -1505,17 +1505,17 @@ void GL_MANGLE(glCopyTexImage2D)( GLenum target, GLint level, GLenum internalfor
 
 void GL_MANGLE(glTexImage1D)( GLenum target, GLint level, GLint internalformat, GLsizei width, GLint border, GLenum format, GLenum type, const GLvoid *pixels )
 {
-	GL_MANGLE(glTexImage2D)( GL_TEXTURE_2D, level, internalformat, width, 1, border, format, type, pixels );
+	GL_MANGLE_NAME(glTexImage2D)( GL_TEXTURE_2D, level, internalformat, width, 1, border, format, type, pixels );
 }
 
 void GL_MANGLE(glTexImage3D)( GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const GLvoid *pixels )
 {
-	GL_MANGLE(glTexImage2D)( GL_TEXTURE_2D, level, internalformat, width, height, border, format, type, pixels );
+	GL_MANGLE_NAME(glTexImage2D)( GL_TEXTURE_2D, level, internalformat, width, height, border, format, type, pixels );
 }
 
 void GL_MANGLE(glTexSubImage1D)( GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format, GLenum type, const GLvoid *pixels )
 {
-	GL_MANGLE(glTexSubImage2D)( target, level, xoffset, 0, width, 1, format, type, pixels );
+	GL_MANGLE_NAME(glTexSubImage2D)( target, level, xoffset, 0, width, 1, format, type, pixels );
 }
 
 void GL_MANGLE(glTexSubImage3D)( GLenum target, GLint level,
@@ -1525,7 +1525,7 @@ void GL_MANGLE(glTexSubImage3D)( GLenum target, GLint level,
                       GLenum format,
                       GLenum type, const GLvoid *pixels )
 {
-	GL_MANGLE(glTexSubImage2D)( target, level, xoffset, yoffset, width, height, format, type, pixels );
+	GL_MANGLE_NAME(glTexSubImage2D)( target, level, xoffset, yoffset, width, height, format, type, pixels );
 }
 
 GLboolean GL_MANGLE(glIsTexture)( GLuint texture )
@@ -2230,7 +2230,7 @@ void GL_MANGLE(glMultiTexCoord2fARB)( GLenum target, GLfloat s, GLfloat t )
 {
 	if ( target == GL_TEXTURE0 )
 	{
-		GL_MANGLE(glTexCoord2f)( s, t );
+		GL_MANGLE_NAME(glTexCoord2f)( s, t );
 	}
 	else
 	{
@@ -2241,12 +2241,12 @@ void GL_MANGLE(glMultiTexCoord2fARB)( GLenum target, GLfloat s, GLfloat t )
 
 void GL_MANGLE(glMultiTexCoord3fARB)( GLenum a, GLfloat b, GLfloat c, GLfloat )
 {
-	return GL_MANGLE(glMultiTexCoord2fARB)( a, b, c );
+	return GL_MANGLE_NAME(glMultiTexCoord2fARB)( a, b, c );
 }
 
 void GL_MANGLE(glMultiTexCoord2f)( GLenum a, GLfloat b, GLfloat c )
 {
-	GL_MANGLE(glMultiTexCoord2fARB)(a,b,c);
+	GL_MANGLE_NAME(glMultiTexCoord2fARB)(a,b,c);
 }
 
 #endif

--- a/nanogl.cpp
+++ b/nanogl.cpp
@@ -80,7 +80,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <dlfcn.h>
 #define loadDriver( x ) dlopen( x, RTLD_NOW | RTLD_LOCAL )
 #define procAddress( x, y ) dlsym( x, y )
-#define freeDriver( x ) dlclose() x )
+#define freeDriver( x ) dlclose( x )
 #define GL_LIB "libGL.so.1"
 #define GLES_LIB "libGLESv1_CM.so"
 #define EGL_LIB "libEGL.so"
@@ -453,5 +453,5 @@ void nanoGL_Destroy( )
 	}
 
 	// release lib
-	dlclose( glesLib );
+	freeDriver( glesLib );
 }


### PR DESCRIPTION
- `XASH_GL_STATIC` and `REF_GL_KEEP_MANGLED_FUNCTIONS` expect gl functions to have `APIENTRY`
- `#define S` breaks windows.h
- typo in `freeDriver`

Tested with Mesa 25.2.0-rc1